### PR TITLE
General improvements and features

### DIFF
--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -33,3 +33,6 @@ worldgate.superextenders (Increase extender range?) bool true
 
 # Glowing Telemosaic beacons?
 worldgate.beaconglow (Glowing Telemosaic beacons?) bool true
+
+# Consume Mese Crystal Fragments after converting to a Telemosaic key? By default, Telemosaic keys are converted back to crystal fragments after use.
+worldgate.destroykeys (Consume Telemosaic keys?) bool false

--- a/src/gates.lua
+++ b/src/gates.lua
@@ -58,22 +58,29 @@ if minetest.settings:get_bool("worldgate.native",true) then
     for x = min, max, spread do
       for z = min, max, spread do
         local pos = vn(x,0,z)
-        surface_gates[minetest.hash_node_position(pos)] = {
+        local hpos = minetest.hash_node_position(pos)
+        surface_gates[hpos] = {
           position = vn(x + pcgr:next(xzjittern,xzjitterp),pcgr:next(0,24),z + pcgr:next(xzjittern,xzjitterp)),
           base = get_random_base(pcgr),
           decor = get_random_decor(pcgr),
           quality = get_random_quality(pcgr),
           exact = false,
           destination = (function() -- placeholder to be converted to an actual gate
-            local neighborx = ({
-              x == min and x + spread or x - spread,
-              x == max and x - spread or x + spread,
-            })[pcgr:next(1,2)]
-            local neighborz = ({
-              z == min and z + spread or z - spread,
-              z == max and z - spread or z + spread,
-            })[pcgr:next(1,2)]
-            return minetest.hash_node_position({ x = neighborx, y = 0, z = neighborz })
+            local nhashes = {
+              minetest.hash_node_position(vn(x == min and x + spread or x - spread,0,z == min and z + spread or z - spread)),
+              minetest.hash_node_position(vn(x == min and x + spread or x - spread,0,z == max and z - spread or z + spread)),
+              minetest.hash_node_position(vn(x == max and x - spread or x + spread,0,z == min and z + spread or z - spread)),
+              minetest.hash_node_position(vn(x == max and x - spread or x + spread,0,z == max and z - spread or z + spread)),
+            }
+            local neighbors = {}
+            for n = 1, 4 do
+              n = nhashes[n]
+              local g = surface_gates[n]
+              if not g or g.destination ~= hpos then
+                neighbors[#neighbors + 1] = n
+              end
+            end
+            return neighbors[1] and neighbors[pcgr:next(1,#neighbors)] or nhashes[pcgr:next(1,4)]
           end)(),
         }
       end

--- a/src/settings_overrides.lua
+++ b/src/settings_overrides.lua
@@ -46,3 +46,33 @@ if minetest.settings:get_bool("worldgate.beaconglow",true) then
     })
   end
 end
+
+-- Override right-click function to consume mese crystal shards after use as a
+-- Telemosaic key, if configured
+if minetest.settings:get_bool("worldgate.destroykeys",true) then
+  local trc = telemosaic.rightclick
+  telemosaic.rightclick = function(pos, node, player, itemstack, pointed_thing)
+    local item = itemstack:get_name()
+    local returned_item = trc(pos, node, player, itemstack, pointed_thing)
+    if item == "telemosaic:key" and returned_item:get_name() == "default:mese_crystal_fragment" then
+      return ItemStack()
+    else
+      return returned_item
+    end
+  end
+
+  for _,beacon in ipairs({
+    "telemosaic:beacon",
+    "telemosaic:beacon_err",
+    "telemosaic:beacon_disabled",
+    "telemosaic:beacon_off",
+    "telemosaic:beacon_protected",
+    "telemosaic:beacon_err_protected",
+    "telemosaic:beacon_disabled_protected",
+    "telemosaic:beacon_off_protected",
+  }) do
+    minetest.override_item(beacon,{
+      on_rightclick = telemosaic.rightclick
+    })
+  end
+end


### PR DESCRIPTION
- **More mapgen attempts** - This makes it more likely that gates will generate successfully, even when the terrain is very uneven or has little valid space to work with.
- **Native Worldgates no longer pair with each other** - Native Worldgates now make an effort to link to a Worldgate that does not link back to it. This results in longer teleportation chains and longer link cycles which allow players to see more of the world as they jump from gate to gate.
- **New option to consume Telemosaic keys** - By default, a Telemosaic key will return the mese crystal fragment used to create it after the key is used. As a way to add a steeper cost to linking gates, a new option is introduced that will cause Telemosaic keys to be consumed on use without returning a mese crystal fragment. This can add a greater challenge to Worldgate interactions in survival worlds. The new option is disabled by default.