### PR TITLE
Convert int settings to numbers via the tonumber function

### DIFF
--- a/src/functions.lua
+++ b/src/functions.lua
@@ -52,8 +52,8 @@ function worldgate.add_gate_unsafe(def)
 end
 
 -- Function for adding new worldgates
-local ymin = math.max(-29900,minetest.settings:get("worldgate.ymin",-29900) or -29900)
-local ymax = math.min(29900,minetest.settings:get("worldgate.ymax",29900) or 29900)
+local ymin = math.max(-29900,tonumber(minetest.settings:get("worldgate.ymin",-29900) or -29900))
+local ymax = math.min(29900,tonumber(minetest.settings:get("worldgate.ymax",29900) or 29900))
 function worldgate.add_gate(def)
   -- Position must be a valid vector
   if not def.position then

--- a/src/gates.lua
+++ b/src/gates.lua
@@ -8,15 +8,15 @@ if minetest.settings:get_bool("worldgate.native",true) then
   local pcgr = PcgRandom(minetest.get_mapgen_setting("seed"))
 
   -- Get distance between gates (spread)
-  local spread = minetest.settings:get("worldgate.native.spread",1000) or 1000
+  local spread = tonumber(minetest.settings:get("worldgate.native.spread",1000) or 1000)
 
   -- Do not generate gates beyond totalmax to prevent any wierdness with world
   -- boundaries
   local totalmax = 29900
 
   -- Get minimum and maximum y values
-  local ymin = math.max(-totalmax,minetest.settings:get("worldgate.ymin",-totalmax) or -totalmax)
-  local ymax = math.min(totalmax,minetest.settings:get("worldgate.ymax",totalmax) or totalmax)
+  local ymin = math.max(-totalmax,tonumber(minetest.settings:get("worldgate.ymin",-totalmax) or -totalmax))
+  local ymax = math.min(totalmax,tonumber(minetest.settings:get("worldgate.ymax",totalmax) or totalmax))
 
   -- Cache frequently used global functions for better performance
   local add_gate = worldgate.add_gate_unsafe -- native gates are made with respect to checks
@@ -36,7 +36,7 @@ if minetest.settings:get_bool("worldgate.native",true) then
 
   -- Generate x/z values with jitter so that worldgate locations are less
   -- predictable
-  local xzjitterp = math.floor(spread * (minetest.settings:get("worldgate.native.xzjitter",12.5) or 12.5) / 100)
+  local xzjitterp = math.floor(spread * tonumber(minetest.settings:get("worldgate.native.xzjitter",12.5) or 12.5) / 100)
   local xzjittern = -xzjitterp
 
   -- Function to get a gate based on an x/y/z coordinate

--- a/src/mapgen.lua
+++ b/src/mapgen.lua
@@ -24,7 +24,7 @@ local vmcache = {} -- VoxelManip data cache, increases performance
 local schematic_airspace = worldgate.modpath .. "/schematics/worldgate_airspace.mts"
 local schematic_platform = worldgate.modpath .. "/schematics/worldgate_platform.mts"
 
-local extender_break_chance = minetest.settings:get("worldgate.breakage",8) or 8
+local extender_break_chance = tonumber(minetest.settings:get("worldgate.breakage",8) or 8)
 
 local quality_selector = {
   [0] = function(pcgr) -- 25% chance for tier 1 extender to be cobblestone


### PR DESCRIPTION
Without use of the `tonumber` function, it is possible that settings with type `int` may be loaded as strings which can cause the mod to crash. This change ensures that all such settings are properly loaded as numbers.