### PR TITLE
Fix possible crash during brick degrade operations

### DIFF
--- a/src/mapgen.lua
+++ b/src/mapgen.lua
@@ -266,7 +266,10 @@ minetest.register_on_generated(function(minp,maxp,blockseed)
     for _,brick in ipairs(bricks) do
       if pcgr:next(1,brick_degrade_chance) == 1 then
         local brick_node = minetest.get_node(brick)
-        minetest.swap_node(brick,{ name = bricks_map[brick_node.name], param2 = brick_node.param2 })
+        local cobble_node = bricks_map[brick_node.name]
+        if cobble_node then
+          minetest.swap_node(brick,{ name = cobble_node, param2 = brick_node.param2 })
+        end
       end
     end
 


### PR DESCRIPTION
This change mitigates a possible crash during the internal process of degrading bricks to cobblestone when a new worldgate is generated. This is likely due to bricks in unloaded chunks sometimes being selected by `minetest.find_nodes_in_area` although I'm not able to reproduce it. This should fix #4.